### PR TITLE
Utility methods in Movie class - deleted.

### DIFF
--- a/src/main/java/com/videoclub/suriken/model/Movie.java
+++ b/src/main/java/com/videoclub/suriken/model/Movie.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class Movie {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
@@ -23,7 +23,8 @@ public class Movie {
 
     private int stock;
 
-    @ManyToMany()
+    @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinTable(name = "movies_their_renters", joinColumns = {@JoinColumn(name = "movie_id")}, inverseJoinColumns = {@JoinColumn(name = "renter_id")})
     private List<MovieRenter> renters = new ArrayList<>();
 
     public Movie(Long id,String name, int year, Genre genre, String director, int stock, List<MovieRenter> renters) {
@@ -37,16 +38,6 @@ public class Movie {
     }
 
     public Movie() {
-    }
-
-    public void addMovieRenter(MovieRenter movieRenter) {
-        renters.add(movieRenter);
-        movieRenter.addRentedMovie(this);
-    }
-
-    public void removeMovieRenter(MovieRenter movieRenter) {
-        renters.remove(movieRenter);
-        movieRenter.removeRentedMovie(this);
     }
 
     public Long getId() {

--- a/src/main/java/com/videoclub/suriken/model/MovieRenter.java
+++ b/src/main/java/com/videoclub/suriken/model/MovieRenter.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class MovieRenter {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String firstName;

--- a/src/main/java/com/videoclub/suriken/service/impl/MovieServiceImpl.java
+++ b/src/main/java/com/videoclub/suriken/service/impl/MovieServiceImpl.java
@@ -52,7 +52,7 @@ public class MovieServiceImpl implements MovieService {
                 .orElseThrow(() -> new RestException("Exception.renterNotFound", new String[]{renterId.toString()}));
 
         movieToRent.decrementStockValueByOne();
-        movieToRent.addMovieRenter(movieRenter);
+        movieToRent.getRenters().add(movieRenter);
         movieRepository.save(movieToRent);
     }
 
@@ -71,7 +71,7 @@ public class MovieServiceImpl implements MovieService {
                 .orElseThrow(() -> new RestException("Exception.renterNotFound", new String[]{renterId.toString()}));
 
         movieToReturn.incrementStockByOne();
-        movieToReturn.removeMovieRenter(movieRenter);
+        movieToReturn.getRenters().remove(movieRenter);
         movieRepository.save(movieToReturn);
     }
 }


### PR DESCRIPTION
There is no need for utility methods in the Movie entity because this entity is set to be **owner** of the _many to many_ associations between Movie and MovieRenter. If object of type Movie is persisted and in that moment it has reference to the object of type MovieRenter, the table is going to be populated as it should - there is no need for MovieRenter object to has reference to the Movie object.